### PR TITLE
Add password reset page and link it from login

### DIFF
--- a/accounts/templates/registration/login.html
+++ b/accounts/templates/registration/login.html
@@ -31,6 +31,10 @@
           <button class="btn btn-secondary w-100" type="submit">Sign in</button>
         </form>
 
+        <p class="mt-3 mb-0 text-center">
+          <a href="{% url 'password_reset' %}" class="text-decoration-none">Forgot your password?</a>
+        </p>
+
         <p class="mt-3 mb-0 text-center text-muted">
           Don’t have an account?
           <a href="mailto:alessandro.milan@uaslp.mx?subject=Request%20Account%20Access%20-%20Dave" class="text-decoration-none text-purple">

--- a/accounts/templates/registration/password_reset_done.html
+++ b/accounts/templates/registration/password_reset_done.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block title %}Password reset sent · Dave{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-12 col-md-6 col-lg-4">
+    <div class="card shadow-sm">
+      <div class="card-body text-center">
+        <h1 class="h4 mb-3">Check your inbox</h1>
+        <p class="text-muted mb-0">If an account exists for the email you entered, you'll receive a message with instructions to reset your password shortly.</p>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/accounts/templates/registration/password_reset_form.html
+++ b/accounts/templates/registration/password_reset_form.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% load form_extras %}
+
+{% block title %}Reset password · Dave{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-12 col-md-6 col-lg-4">
+    <div class="card shadow-sm">
+      <div class="card-body">
+        <h1 class="h4 mb-3 text-center">Reset your password</h1>
+        <p class="text-muted">Enter the email address associated with your account, and we'll send you a link to reset your password.</p>
+        <form method="post">
+          {% csrf_token %}
+          <div class="mb-3">
+            <label for="id_email" class="form-label">Email address</label>
+            {{ form.email|add_class:"form-control" }}
+          </div>
+          <button class="btn btn-secondary w-100" type="submit">Send reset link</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -5,6 +5,16 @@ from . import views
 urlpatterns = [
     path("login/",  auth_views.LoginView.as_view(template_name="registration/login.html"), name="login"),
     path("logout/", auth_views.LogoutView.as_view(), name="logout"),
+    path(
+        "password-reset/",
+        auth_views.PasswordResetView.as_view(template_name="registration/password_reset_form.html"),
+        name="password_reset",
+    ),
+    path(
+        "password-reset/done/",
+        auth_views.PasswordResetDoneView.as_view(template_name="registration/password_reset_done.html"),
+        name="password_reset_done",
+    ),
 
     path("settings/", views.account_settings, name="account_settings"),
 


### PR DESCRIPTION
## Summary
- add password reset and confirmation routes to the accounts app
- create templates for requesting a reset and showing the confirmation message
- link the login page to the new password reset flow

## Testing
- `python manage.py check` *(fails: ImportError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_68df0c436d74832384a147e2b19d0e24